### PR TITLE
media3 integration, handle audio focus gain/lost

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,7 +125,9 @@ dependencies {
     implementation 'androidx.camera:camera-view:1.0.0-alpha32'
 
     implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:17.0.0'
-    implementation 'com.google.android.exoplayer:exoplayer:2.16.1'
+    implementation 'androidx.media3:media3-exoplayer:1.0.0-alpha01'
+    implementation 'androidx.media3:media3-ui:1.0.0-alpha01'
+    implementation 'androidx.media3:media3-session:1.0.0-alpha01'
 
     implementation "androidx.palette:palette-ktx:1.0.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
             </intent-filter>
         </activity>
 
+        <service android:name=".features.exoPlayer.SampleMediaSessionService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService"/>
+                <action android:name="android.media.browse.MediaBrowserService"/>
+            </intent-filter>
+        </service>
+
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="AIzaSyANU9EllOVGyMnpOANajwjD91qrZIhoJa0" />

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/SampleMediaSessionService.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/SampleMediaSessionService.kt
@@ -1,0 +1,46 @@
+package com.skyyo.samples.features.exoPlayer
+
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaSession
+
+class SampleMediaSessionService: MediaLibraryService() {
+    private lateinit var mediaLibrarySession: MediaLibrarySession
+    private lateinit var player: ExoPlayer
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaLibrarySession
+
+    override fun onCreate() {
+        super.onCreate()
+        player = ExoPlayer.Builder(this)
+            .setAudioAttributes(AudioAttributes.DEFAULT, /* handleAudioFocus= */ true)
+            .build()
+
+        mediaLibrarySession = MediaLibrarySession.Builder(this, player, object: MediaLibrarySession.MediaLibrarySessionCallback {})
+            .setMediaItemFiller(MediaItemFiller())
+            .build()
+    }
+
+    class MediaItemFiller : MediaSession.MediaItemFiller {
+        override fun fillInLocalConfiguration(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItem: MediaItem
+        ): MediaItem {
+            // Return the media item that will be played
+            return MediaItem.Builder()
+                // Use the metadata values to fill our media item
+                .setUri(mediaItem.mediaMetadata.mediaUri)
+                .setMediaMetadata(mediaItem.mediaMetadata)
+                .build()
+        }
+    }
+
+    override fun onDestroy() {
+        mediaLibrarySession.release()
+        player.release()
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/VideoPlayer.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/VideoPlayer.kt
@@ -1,5 +1,6 @@
 package com.skyyo.samples.features.exoPlayer
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import androidx.compose.foundation.background
@@ -11,13 +12,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.ui.PlayerView
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.PlayerView
 import com.skyyo.samples.R
 
 @Composable
+@SuppressLint("UnsafeOptInUsageError")
+@OptIn(UnstableApi::class)
 fun VideoPlayer(
-    exoPlayer: SimpleExoPlayer,
+    exoPlayer: Player,
     onControllerVisibilityChanged: (uiVisible: Boolean) -> Unit
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/VideoPlayerWithControls.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/VideoPlayerWithControls.kt
@@ -1,5 +1,6 @@
 package com.skyyo.samples.features.exoPlayer
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageButton
@@ -12,12 +13,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.ui.PlayerView
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
 import com.skyyo.samples.R
 
+@SuppressLint("UnsafeOptInUsageError")
+@OptIn(UnstableApi::class)
 @Composable
-fun VideoPlayerWithControls(exoPlayer: SimpleExoPlayer) {
+fun VideoPlayerWithControls(exoPlayer: ExoPlayer) {
     val context = LocalContext.current
     val playerView = remember {
         val layout = LayoutInflater.from(context).inflate(R.layout.video_player_auto, null)

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/AutoPlayVideoCard.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/AutoPlayVideoCard.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.google.android.exoplayer2.SimpleExoPlayer
+import androidx.media3.exoplayer.ExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItem
 import com.skyyo.samples.features.exoPlayer.VideoPlayerWithControls
 import com.skyyo.samples.features.exoPlayer.common.VideoThumbnail
@@ -22,7 +22,7 @@ import com.skyyo.samples.theme.Shapes
 fun AutoPlayVideoCard(
     videoItem: VideoItem,
     isPlaying: Boolean,
-    exoPlayer: SimpleExoPlayer,
+    exoPlayer: ExoPlayer,
 ) {
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/ExoPlayerColumnAutoplayScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/ExoPlayerColumnAutoplayScreen.kt
@@ -1,5 +1,6 @@
 package com.skyyo.samples.features.exoPlayer.columnAutoplay
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,20 +17,23 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.rememberInsetsPaddingValues
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItem
 import kotlinx.coroutines.flow.collect
 import kotlin.math.abs
 
+@SuppressLint("UnsafeOptInUsageError")
+@OptIn(UnstableApi::class)
 @Composable
 fun ExoPlayerColumnAutoplayScreen(viewModel: ExoPlayerColumnAutoplayViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val listState = rememberLazyListState()
-    val exoPlayer = remember { SimpleExoPlayer.Builder(context).build() }
+    val exoPlayer = remember { ExoPlayer.Builder(context).build() }
     val videos by viewModel.videos.observeAsState(listOf())
     val playingVideoItem = remember { mutableStateOf(videos.firstOrNull()) }
 

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/ExoPlayerColumnDynamicThumbScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/ExoPlayerColumnDynamicThumbScreen.kt
@@ -1,5 +1,6 @@
 package com.skyyo.samples.features.exoPlayer.columnDynamicThumb
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,25 +17,27 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import coil.ImageLoader
 import coil.decode.VideoFrameDecoder
 import coil.fetch.VideoFrameFileFetcher
 import coil.fetch.VideoFrameUriFetcher
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.rememberInsetsPaddingValues
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.skyyo.samples.features.exoPlayer.columnIndexed.ExoPlayerColumnIndexedViewModel
 import com.skyyo.samples.features.exoPlayer.common.VideoItemImmutable
 import kotlinx.coroutines.flow.collect
 
-
+@SuppressLint("UnsafeOptInUsageError")
+@OptIn(UnstableApi::class)
 @Composable
 fun ExoPlayerColumnDynamicThumbScreen(viewModel: ExoPlayerColumnIndexedViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    val exoPlayer = remember(context) { SimpleExoPlayer.Builder(context).build() }
+    val exoPlayer = remember(context) { ExoPlayer.Builder(context).build() }
     val listState = rememberLazyListState()
     // can / should? be provided by dagger if used in multiple places
     val imageLoader = remember {

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/VideoCardDynamicThumb.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/VideoCardDynamicThumb.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.skyyo.samples.R
 import com.skyyo.samples.features.exoPlayer.VideoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItemImmutable
@@ -34,7 +33,7 @@ fun VideoCardIndexed(
     imageLoader: ImageLoader,
     isPlaying: Boolean,
     onClick: OnClick,
-    exoPlayer: SimpleExoPlayer
+    exoPlayer: androidx.media3.exoplayer.ExoPlayer
 ) {
     val isPlayerUiVisible = remember { mutableStateOf(false) }
     val isPlayButtonVisible = if (isPlayerUiVisible.value) true else !isPlaying

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/ExoPlayerColumnIndexedScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/ExoPlayerColumnIndexedScreen.kt
@@ -1,5 +1,6 @@
 package com.skyyo.samples.features.exoPlayer.columnIndexed
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,20 +17,23 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.rememberInsetsPaddingValues
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItemImmutable
 import kotlinx.coroutines.flow.collect
 
 
+@SuppressLint("UnsafeOptInUsageError")
+@OptIn(UnstableApi::class)
 @Composable
 fun ExoPlayerColumnIndexedScreen(viewModel: ExoPlayerColumnIndexedViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    val exoPlayer = remember(context) { SimpleExoPlayer.Builder(context).build() }
+    val exoPlayer = remember(context) { ExoPlayer.Builder(context).build() }
     val listState = rememberLazyListState()
 
     val videos by viewModel.videos.observeAsState(listOf())

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/VideoCardIndexed.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/VideoCardIndexed.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.media3.exoplayer.ExoPlayer
 import coil.annotation.ExperimentalCoilApi
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.skyyo.samples.R
 import com.skyyo.samples.features.exoPlayer.VideoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoThumbnail
@@ -32,7 +32,7 @@ fun VideoCardIndexed(
     modifier: Modifier = Modifier,
     videoItem: VideoItemImmutable,
     isPlaying: Boolean,
-    exoPlayer: SimpleExoPlayer,
+    exoPlayer: ExoPlayer,
     onClick: OnClick
 ) {
     val isPlayerUiVisible = remember { mutableStateOf(false) }

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnReference/VideoCardReference.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnReference/VideoCardReference.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.google.android.exoplayer2.SimpleExoPlayer
+import androidx.media3.common.Player
 import com.skyyo.samples.R
 import com.skyyo.samples.features.exoPlayer.VideoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItem
@@ -30,10 +30,10 @@ fun VideoCardReference(
     modifier: Modifier = Modifier,
     videoItem: VideoItem,
     isPlaying: Boolean,
-    exoPlayer: SimpleExoPlayer,
+    exoPlayer: Player,
     onClick: OnClick
 ) {
-    val isPlayerUiVisible = remember { mutableStateOf(false) }
+    val isPlayerUiVisible = remember(isPlaying) { mutableStateOf(isPlaying) }
 
     Box(
         modifier = modifier

--- a/app/src/main/res/layout/exoplayer_controls.xml
+++ b/app/src/main/res/layout/exoplayer_controls.xml
@@ -35,7 +35,7 @@
         android:textColor="@android:color/white"
         tools:text="00-00" />
 
-    <com.google.android.exoplayer2.ui.DefaultTimeBar
+    <androidx.media3.ui.DefaultTimeBar
         android:id="@id/exo_progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/video_player.xml
+++ b/app/src/main/res/layout/video_player.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.exoplayer2.ui.PlayerView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.media3.ui.PlayerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/playerView"

--- a/app/src/main/res/layout/video_player_auto.xml
+++ b/app/src/main/res/layout/video_player_auto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.exoplayer2.ui.PlayerView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.media3.ui.PlayerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/playerView"


### PR DESCRIPTION
Media3 pros:
- same player interface, which ease switching from playing in activity to playing in service
- out of the box integration with wear watches, google assistant, bluetooth headset etc. (by implementing mediasessionservice)
- exoplayer as core, so switching from exoplayer is straightforward

Cons: 
- Need to refactor
- New bugs, such as crashing when playing in mediasessionservice. (which forces to use media metadata+medialibraryservice+mediaitemfiller).