### PR TITLE
Replaced collectAsState with collectAsStateWithLifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha02"
 
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"

--- a/app/src/main/java/com/skyyo/samples/features/cardRecognition/CardRecognitionScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/cardRecognition/CardRecognitionScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,8 +21,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.gms.wallet.PaymentCardRecognitionResult
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CardRecognitionScreen(viewModel: CardRecognitionViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -38,8 +40,8 @@ fun CardRecognitionScreen(viewModel: CardRecognitionViewModel = hiltViewModel())
             }
         }
     }
-    val cardRecognitionIntent by viewModel.cardRecognitionPendingIntent.collectAsState()
-    val isCardRecognitionSupported by viewModel.isCardRecognitionSupported.collectAsState()
+    val cardRecognitionIntent by viewModel.cardRecognitionPendingIntent.collectAsStateWithLifecycle()
+    val isCardRecognitionSupported by viewModel.isCardRecognitionSupported.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/ExoPlayerColumnAutoplayScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnAutoplay/ExoPlayerColumnAutoplayScreen.kt
@@ -13,18 +13,21 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItem
 import kotlin.math.abs
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun ExoPlayerColumnAutoplayScreen(viewModel: ExoPlayerColumnAutoplayViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val listState = rememberLazyListState()
     val exoPlayer = remember { ExoPlayer.Builder(context).build() }
-    val videos by viewModel.videos.collectAsState()
+    val videos by viewModel.videos.collectAsStateWithLifecycle()
     var playingVideoItem by remember { mutableStateOf(videos.firstOrNull()) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/ExoPlayerColumnDynamicThumbScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnDynamicThumb/ExoPlayerColumnDynamicThumbScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import coil.ComponentRegistry
@@ -21,6 +23,7 @@ import coil.decode.VideoFrameDecoder
 import com.skyyo.samples.features.exoPlayer.columnIndexed.ExoPlayerColumnIndexedViewModel
 import com.skyyo.samples.features.exoPlayer.common.VideoItemImmutable
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun ExoPlayerColumnDynamicThumbScreen(viewModel: ExoPlayerColumnIndexedViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -37,8 +40,8 @@ fun ExoPlayerColumnDynamicThumbScreen(viewModel: ExoPlayerColumnIndexedViewModel
             .build()
     }
 
-    val videos by viewModel.videos.collectAsState()
-    val playingItemIndex by viewModel.currentlyPlayingIndex.collectAsState()
+    val videos by viewModel.videos.collectAsStateWithLifecycle()
+    val playingItemIndex by viewModel.currentlyPlayingIndex.collectAsStateWithLifecycle()
     var isCurrentItemVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/ExoPlayerColumnIndexedScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnIndexed/ExoPlayerColumnIndexedScreen.kt
@@ -13,10 +13,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItemImmutable
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun ExoPlayerColumnIndexedScreen(viewModel: ExoPlayerColumnIndexedViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -25,8 +28,8 @@ fun ExoPlayerColumnIndexedScreen(viewModel: ExoPlayerColumnIndexedViewModel = hi
     val exoPlayer = remember(context) { ExoPlayer.Builder(context).build() }
     val listState = rememberLazyListState()
 
-    val videos by viewModel.videos.collectAsState()
-    val playingItemIndex by viewModel.currentlyPlayingIndex.collectAsState()
+    val videos by viewModel.videos.collectAsStateWithLifecycle()
+    val playingItemIndex by viewModel.currentlyPlayingIndex.collectAsStateWithLifecycle()
     var isCurrentItemVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnReference/ExoPlayerColumnReferenceScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/exoPlayer/columnReference/ExoPlayerColumnReferenceScreen.kt
@@ -13,18 +13,21 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import com.skyyo.samples.features.exoPlayer.common.VideoItem
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun ExoPlayerColumnReferenceScreen(viewModel: ExoPlayerColumnReferenceViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val exoPlayer = remember { ExoPlayer.Builder(context).build() }
     val listState = rememberLazyListState()
-    val videos by viewModel.videos.collectAsState()
-    val playingVideoItem by viewModel.currentlyPlayingItem.collectAsState()
+    val videos by viewModel.videos.collectAsStateWithLifecycle()
+    val playingVideoItem by viewModel.currentlyPlayingItem.collectAsStateWithLifecycle()
     var isPlayingItemVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/skyyo/samples/features/googlePay/GooglePayScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/googlePay/GooglePayScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -24,16 +23,19 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skyyo.samples.R
 import com.skyyo.samples.extensions.getEnclosingActivity
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun GooglePayScreen(viewModel: GooglePayViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val activity = context.getEnclosingActivity()
-    val isWalletSupported by viewModel.isWalletSupported.collectAsState()
-    val passData1 by viewModel.passData1.collectAsState()
-    val passData2 by viewModel.passData2.collectAsState()
+    val isWalletSupported by viewModel.isWalletSupported.collectAsStateWithLifecycle()
+    val passData1 by viewModel.passData1.collectAsStateWithLifecycle()
+    val passData2 by viewModel.passData2.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/skyyo/samples/features/healthConnect/HealthConnectScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/healthConnect/HealthConnectScreen.kt
@@ -20,25 +20,28 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.Permission
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.skyyo.samples.utils.OnClick
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun HealthConnectScreen(viewModel: HealthConnectViewModel = hiltViewModel()) {
     val context = LocalContext.current
     var isHealthConnectAvailable by remember { mutableStateOf(false) }
     val permissions = viewModel.permissions
-    val stepsWritten by viewModel.stepsWritten.collectAsState()
-    val stepsRead by viewModel.stepsRead.collectAsState()
-    val localStepsCanBeRead by viewModel.localStepsCanBeRead.collectAsState()
-    val accumulated3rdPartySteps by viewModel.accumulated3rdPartySteps.collectAsState()
+    val stepsWritten by viewModel.stepsWritten.collectAsStateWithLifecycle()
+    val stepsRead by viewModel.stepsRead.collectAsStateWithLifecycle()
+    val localStepsCanBeRead by viewModel.localStepsCanBeRead.collectAsStateWithLifecycle()
+    val accumulated3rdPartySteps by viewModel.accumulated3rdPartySteps.collectAsStateWithLifecycle()
     val localLifecycle = LocalLifecycleOwner.current.lifecycle
 
     val healthConnectPermissionState =
         rememberHealthConnectPermissionState(viewModel.healthConnectClient, permissions, viewModel::checkPermissions)
-    val areAllPermissionsGranted by viewModel.areAllPermissionsGranted.collectAsState()
+    val areAllPermissionsGranted by viewModel.areAllPermissionsGranted.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         callbackFlow {

--- a/app/src/main/java/com/skyyo/samples/features/inputValidations/auto/InputValidationAutoScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/inputValidations/auto/InputValidationAutoScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.skyyo.samples.R
 import com.skyyo.samples.extensions.toast
@@ -28,7 +30,7 @@ import com.skyyo.samples.features.inputValidations.FocusedTextFieldKey
 import com.skyyo.samples.features.inputValidations.ScreenEvent
 import com.skyyo.samples.utils.creditCardFilter
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalLifecycleComposeApi::class)
 @Composable
 fun InputValidationAutoScreen(viewModel: InputValidationAutoViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -43,9 +45,9 @@ fun InputValidationAutoScreen(viewModel: InputValidationAutoViewModel = hiltView
         )
     }
 
-    val name by viewModel.name.collectAsState()
-    val creditCardNumber by viewModel.creditCardNumber.collectAsState()
-    val areInputsValid by viewModel.areInputsValid.collectAsState()
+    val name by viewModel.name.collectAsStateWithLifecycle()
+    val creditCardNumber by viewModel.creditCardNumber.collectAsStateWithLifecycle()
+    val areInputsValid by viewModel.areInputsValid.collectAsStateWithLifecycle()
 
     val creditCardNumberFocusRequester = remember { FocusRequester() }
     val nameFocusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/skyyo/samples/features/inputValidations/autoDebounce/InputValidationAutoDebounceScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/inputValidations/autoDebounce/InputValidationAutoDebounceScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.skyyo.samples.R
 import com.skyyo.samples.extensions.toast
@@ -28,7 +30,7 @@ import com.skyyo.samples.features.inputValidations.FocusedTextFieldKey
 import com.skyyo.samples.features.inputValidations.ScreenEvent
 import com.skyyo.samples.utils.creditCardFilter
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalLifecycleComposeApi::class)
 @Composable
 fun InputValidationAutoDebounceScreen(
     viewModel: InputValidationAutoDebounceViewModel = hiltViewModel()
@@ -45,9 +47,9 @@ fun InputValidationAutoDebounceScreen(
         )
     }
 
-    val name by viewModel.name.collectAsState()
-    val creditCardNumber by viewModel.creditCardNumber.collectAsState()
-    val areInputsValid by viewModel.areInputsValid.collectAsState()
+    val name by viewModel.name.collectAsStateWithLifecycle()
+    val creditCardNumber by viewModel.creditCardNumber.collectAsStateWithLifecycle()
+    val areInputsValid by viewModel.areInputsValid.collectAsStateWithLifecycle()
 
     val creditCardNumberFocusRequester = remember { FocusRequester() }
     val nameFocusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/skyyo/samples/features/inputValidations/manual/InputValidationManualScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/inputValidations/manual/InputValidationManualScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.skyyo.samples.R
 import com.skyyo.samples.extensions.toast
@@ -27,7 +29,7 @@ import com.skyyo.samples.features.inputValidations.*
 import com.skyyo.samples.utils.creditCardFilter
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalLifecycleComposeApi::class)
 @Composable
 fun InputValidationManualScreen(viewModel: InputValidationManualViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -42,11 +44,11 @@ fun InputValidationManualScreen(viewModel: InputValidationManualViewModel = hilt
         )
     }
 
-    val name by viewModel.name.collectAsState()
-    val creditCardNumber by viewModel.creditCardNumber.collectAsState()
+    val name by viewModel.name.collectAsStateWithLifecycle()
+    val creditCardNumber by viewModel.creditCardNumber.collectAsStateWithLifecycle()
 
-    val nameErrorId by viewModel.nameErrorId.collectAsState()
-    val creditCardNumberErrorId by viewModel.creditCardNumberErrorId.collectAsState()
+    val nameErrorId by viewModel.nameErrorId.collectAsStateWithLifecycle()
+    val creditCardNumberErrorId by viewModel.creditCardNumberErrorId.collectAsStateWithLifecycle()
 
     val creditCardNumberFocusRequester = remember { FocusRequester() }
     val nameFocusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/skyyo/samples/features/navigateWithResult/simple/dogFeed/DogFeedScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/navigateWithResult/simple/dogFeed/DogFeedScreen.kt
@@ -6,13 +6,15 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun DogFeedScreen(viewModel: DogFeedViewModel = hiltViewModel()) {
-    val dog = viewModel.dogStatus.collectAsState()
+    val dog = viewModel.dogStatus.collectAsStateWithLifecycle()
 
     Column(Modifier.fillMaxSize()) {
         Button(viewModel::goDogDetails, Modifier.statusBarsPadding()) {

--- a/app/src/main/java/com/skyyo/samples/features/navigateWithResult/withObject/catFeed/CatFeedScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/navigateWithResult/withObject/catFeed/CatFeedScreen.kt
@@ -6,14 +6,16 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skyyo.samples.features.navigateWithResult.withObject.catFeed.CatFeedViewModel as CatFeedViewModel1
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CatFeedScreen(viewModel: CatFeedViewModel1 = hiltViewModel()) {
-    val cat = viewModel.cat.collectAsState()
+    val cat = viewModel.cat.collectAsStateWithLifecycle()
     Column(Modifier.fillMaxSize()) {
         Button(viewModel::goCatDetails, Modifier.statusBarsPadding()) {
             Text(text = "Cat Feed: go details!")

--- a/app/src/main/java/com/skyyo/samples/features/otp/OtpScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/otp/OtpScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skyyo.samples.features.inputValidations.InputWrapper
 import com.skyyo.samples.features.inputValidations.OnValueChange
 import com.skyyo.samples.features.otp.composables.OtpCharTextField
@@ -35,9 +37,10 @@ import com.skyyo.samples.theme.Error
 import com.skyyo.samples.theme.Teal200
 import com.skyyo.samples.utils.OnKeyActionDone
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun OtpScreen(viewModel: OtpViewModel = hiltViewModel()) {
-    val input by viewModel.input.collectAsState()
+    val input by viewModel.input.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/skyyo/samples/features/pagination/simple/CatsScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/pagination/simple/CatsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
@@ -29,6 +31,7 @@ import com.skyyo.samples.theme.DarkGray
 import com.skyyo.samples.theme.White
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CatsScreen(viewModel: CatsViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -46,9 +49,9 @@ fun CatsScreen(viewModel: CatsViewModel = hiltViewModel()) {
         )
     }
 
-    val cats by viewModel.cats.collectAsState()
-    val isRefreshing by viewModel.isRefreshing.collectAsState()
-    val isLastPageReached by viewModel.isLastPageReached.collectAsState()
+    val cats by viewModel.cats.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val isLastPageReached by viewModel.isLastPageReached.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         events.collect { event ->

--- a/app/src/main/java/com/skyyo/samples/features/pagination/simpleWithDatabase/CatsRoomScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/pagination/simpleWithDatabase/CatsRoomScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
@@ -29,6 +31,7 @@ import com.skyyo.samples.theme.DarkGray
 import com.skyyo.samples.theme.White
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CatsRoomScreen(viewModel: CatsRoomViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -45,9 +48,9 @@ fun CatsRoomScreen(viewModel: CatsRoomViewModel = hiltViewModel()) {
             Lifecycle.State.STARTED
         )
     }
-    val cats by viewModel.cats.collectAsState()
-    val isRefreshing by viewModel.isRefreshing.collectAsState()
-    val isLastPageReached by viewModel.isLastPageReached.collectAsState()
+    val cats by viewModel.cats.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val isLastPageReached by viewModel.isLastPageReached.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         events.collect { event ->

--- a/app/src/main/java/com/skyyo/samples/features/pdfViewer/PdfViewerScreen.kt
+++ b/app/src/main/java/com/skyyo/samples/features/pdfViewer/PdfViewerScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionRequired
 import com.google.accompanist.permissions.rememberPermissionState
@@ -43,13 +45,13 @@ import java.io.File
 import java.io.InputStream
 import java.util.concurrent.Executors
 
-@OptIn(ExperimentalPermissionsApi::class)
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalLifecycleComposeApi::class)
 @Composable
 fun PdfViewerScreen(viewModel: PdfViewerViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val storagePermissionState = rememberPermissionState(Manifest.permission.READ_EXTERNAL_STORAGE)
-    val uri by viewModel.uri.collectAsState()
-    val pdfRenderer by viewModel.pdfRenderer.collectAsState()
+    val uri by viewModel.uri.collectAsStateWithLifecycle()
+    val pdfRenderer by viewModel.pdfRenderer.collectAsStateWithLifecycle()
     val executor = remember { Executors.newSingleThreadExecutor().asCoroutineDispatcher() }
 
     PermissionRequired(


### PR DESCRIPTION
Replaced `collectAsState` with `collectAsStateWithLifecycle` to enhance memory consumption
Closes #50 